### PR TITLE
Add åäö with Western (Windows 1252) encoding

### DIFF
--- a/app/src/main/java/unmappable_character/App.java
+++ b/app/src/main/java/unmappable_character/App.java
@@ -5,7 +5,7 @@ package unmappable_character;
 
 public class App {
     public String getGreeting() {
-        return "Hello World!";
+        return "Hello World! едц";
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This repo and PR is created in order to show that the build succeeds even though there is an encoding error during build time.

---

`org.gradle.jvmargs=-Dfile.encoding=UTF-8` is set in `gradle.properties` in order to enforce UTF-8 encoding.

This PR adds the Swedish characters `åäö` using Western (Windows 1252) encoding. The build fails when building locally on my computer.

![image](https://user-images.githubusercontent.com/60508776/106432648-4cf1e200-646f-11eb-884a-7a1549c5ddd6.png)


However, the build succeeds when builing using GitHub actions.

![image](https://user-images.githubusercontent.com/60508776/106432588-39467b80-646f-11eb-8034-a2ba2e38c1de.png)

The build errors must fail the GitHub action build, but it does not:

![image](https://user-images.githubusercontent.com/60508776/106432828-8d516000-646f-11eb-8aff-7f1de980e3c7.png)
